### PR TITLE
Enables build and deployment of owlery as a Docker container

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,71 @@
+FROM openjdk:8-jdk
+
+LABEL maintainer="hilmar.lapp@duke.edu"
+
+# Prevent error messages from debconf about non-interactive frontend
+ARG TERM=linux
+ARG DEBIAN_FRONTEND=noninteractive
+
+# create designated non-root system user and group
+ARG OWLERY_USER=owlery
+ARG OWLERY_GROUP=owlery
+
+ADD create-user.sh /usr/local/bin/create-service-user
+RUN chmod ug+x /usr/local/bin/create-service-user && \
+    create-service-user $OWLERY_USER $OWLERY_GROUP
+
+# Install dependencies of sbt
+RUN apt-get update -y && \
+    apt-get install -y apt-utils && \
+    apt-get install -y \
+            apt-transport-https \
+            fakeroot
+
+# Install sbt (Scala Build Tool) through its Debian package directory.
+RUN echo "deb https://dl.bintray.com/sbt/debian /" > \
+         /etc/apt/sources.list.d/sbt.list && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
+                --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+
+RUN apt-get update -y && \
+    apt-get install -y   \
+            sbt
+
+# Download and unpack owlery from the latest release on Github
+RUN curl -L -o /tmp/owlery.tar.gz \
+         $(curl -s https://api.github.com/repos/phenoscape/owlery/releases/latest | grep tarball_url | cut -d\" -f4) && \
+    mkdir /tmp/owlery && \
+    tar -z -x -v --strip-components 1 -C /tmp/owlery -f /tmp/owlery.tar.gz
+
+# Build owlery (using sbt)
+RUN cd /tmp/owlery && \
+    sbt stage
+
+# then install to /usr/share, adding a symlink to /usr/local/bin, and
+# end by cleaning up
+RUN cd /tmp/owlery && \
+    mv target/universal/stage /usr/share/owlery && \
+    chmod a+x /usr/share/owlery/bin/owlery && \
+    ln -s /usr/share/owlery/bin/owlery /usr/local/bin/owlery && \
+    rm -rf /tmp/owlery*
+
+# create the mount point for configuration files
+RUN mkdir /srv/conf
+
+# owlery needs a significant amount of memory; you may have to increase this
+# (use --env on the docker run command line to override)
+ENV JAVA_OPTS="-Xmx8G"
+
+# the port on which owlery will be listening within the container
+EXPOSE 8080
+
+# run the service under a designated user rather than root
+USER $OWLERY_USER
+
+# by default, the application config file is expected at this location
+# (override on the docker run commandline by providing a trailing argument)
+CMD ["-Dconfig.file=/srv/conf/application.conf"]
+
+# this will have to run on port 8080 and bind to 0.0.0.0 to work, so we
+# override here on the command line whatever the configuration file has
+ENTRYPOINT ["/usr/share/owlery/bin/owlery", "-Dowlery.port=8080", "-Dowlery.host=0.0.0.0"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,6 +2,10 @@ FROM openjdk:8-jdk
 
 LABEL maintainer="hilmar.lapp@duke.edu"
 
+# For which target within owlery to build? If empty, uses the latest
+# release. Otherwise, the branch, or tag, for which to build the container.
+ARG TARGET
+
 # Prevent error messages from debconf about non-interactive frontend
 ARG TERM=linux
 ARG DEBIAN_FRONTEND=noninteractive
@@ -32,8 +36,10 @@ RUN apt-get update -y && \
             sbt
 
 # Download and unpack owlery from the latest release on Github
-RUN curl -L -o /tmp/owlery.tar.gz \
-         $(curl -s https://api.github.com/repos/phenoscape/owlery/releases/latest | grep tarball_url | cut -d\" -f4) && \
+ADD get-tarball-url.sh /tmp/get-tarball-url.sh
+RUN echo "Building owlery from "$(sh /tmp/get-tarball-url.sh $TARGET) && \
+    curl -L -o /tmp/owlery.tar.gz \
+         $(sh /tmp/get-tarball-url.sh $TARGET) && \
     mkdir /tmp/owlery && \
     tar -z -x -v --strip-components 1 -C /tmp/owlery -f /tmp/owlery.tar.gz
 
@@ -47,7 +53,7 @@ RUN cd /tmp/owlery && \
     mv target/universal/stage /usr/share/owlery && \
     chmod a+x /usr/share/owlery/bin/owlery && \
     ln -s /usr/share/owlery/bin/owlery /usr/local/bin/owlery && \
-    rm -rf /tmp/owlery*
+    rm -rf /tmp/owlery* /tmp/get-tarball-url*
 
 # create the mount point for configuration files
 RUN mkdir /srv/conf

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,28 @@
+# Docker container for Owlery
+
+This Docker container will automatically run the owlery service, exposed on
+port 8080 (map to a port suitable for you on the host).
+
+## Runtime customization
+
+### application.conf
+By defaut, the service will expect the `application.conf` file at `/srv/conf/application.conf`. Map the directory where you have your conf file to this path, or alternatively override the location on the `docker run` command line (append `-Dconfig.file=</path/to/application.conf>` after the image name).
+
+Note that the `owlery.port` and `owlery.host` settings in your `application.conf` are irrelevant, because they are overridden in the entrypoint definition for the container.
+
+### Java memory and other options
+Owlery will typically benefit from a fair amount of memory. The reasoner will load into and hold in memory all ontologies you configure. By default, Java is allowed up to 8GB of memory in the container.
+
+You can change the memory available to Java, and other options, by setting the `JAVA_OPTS` environment on the `docker run` command line, by using the `--env` option. Note that this will override the default setting, and hence if you set the environemnt, you must include the increased memory as well.
+
+## Build configuration
+
+Currently the following build arguments (`--build-arg` command line option to `docker build`) are supported:
+
+* `OWLERY_USER` and `OWLERY_GROUP`: designated user and group for running
+  the owlery process within the container (default: `owlery`)
+* `TARGET`: the target to build, as the branch, tag, or release. By default,
+  the _latest release_ is built (this may not be the latest _tag_). To build
+  a specific branch or tag, set `TARGET` to the corresponding value (e.g.,
+  `--build-arg TARGET=master` to build from the master branch).
+

--- a/Docker/create-user.sh
+++ b/Docker/create-user.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+GROUP=${2:-owlery}
+USER=${1:-owlery}
+
+# Adding desired system group
+if ! getent group $GROUP > /dev/null 2>&1 ; then
+    echo "Creating system group: $GROUP"
+    addgroup --system $GROUP
+fi
+
+# Adding desired system user
+if ! id -u $USER > /dev/null 2>&1; then
+    echo "Creating user $USER in group $GROUP"
+    useradd --system --no-create-home --gid $GROUP --shell /bin/false $USER
+fi

--- a/Docker/get-tarball-url.sh
+++ b/Docker/get-tarball-url.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+TARGET=$1
+
+if [ -z $TARGET ] ; then
+    echo $(curl -s https://api.github.com/repos/phenoscape/owlery/releases/latest | grep tarball_url | cut -d\" -f4)
+else
+    echo "https://api.github.com/repos/phenoscape/owlery/tarball/$TARGET"
+fi


### PR DESCRIPTION
At this point, this owlery container will be built _only_ off of the latest _release_ tag. Changes to master or creating normal tags will not result in changed container. This is probably worth making more flexible later.