### PR TITLE
Include ontology IRI and version IRI, and imports, in kb info.

### DIFF
--- a/docs/json/context.jsonld
+++ b/docs/json/context.jsonld
@@ -23,6 +23,14 @@
     },
     "value": {
       "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+    },
+    "version": {
+      "@id": "http://www.w3.org/2002/07/owl#versionIRI",
+      "@type": "@id"
+    },
+    "imports": {
+      "@id": "http://www.w3.org/2002/07/owl#imports",
+      "@type": "@id"
     }
   }
 }

--- a/src/main/scala/org/phenoscape/owlery/Knowledgebase.scala
+++ b/src/main/scala/org/phenoscape/owlery/Knowledgebase.scala
@@ -5,6 +5,7 @@ import org.phenoscape.owlery.Util.OptionalOption
 import org.phenoscape.owlet.Owlet
 import org.semanticweb.owlapi.apibinding.OWLManager
 import org.semanticweb.owlapi.model._
+import org.semanticweb.owlapi.model.parameters.Imports
 import org.semanticweb.owlapi.reasoner.OWLReasoner
 import org.semanticweb.owlapi.search.EntitySearcher
 import spray.json.DefaultJsonProtocol._
@@ -94,7 +95,7 @@ case class Knowledgebase(name: String, reasoner: OWLReasoner) {
       "imports" -> imports.toJson,
       //"reasoner" -> reasoner.getReasonerName.toJson, //FIXME currently HermiT returns null
       "isConsistent" -> reasoner.isConsistent.toJson,
-      "logicalAxiomsCount" -> reasoner.getRootOntology.getLogicalAxiomCount.toJson)
+      "logicalAxiomsCount" -> reasoner.getRootOntology.getLogicalAxiomCount(Imports.INCLUDED).toJson)
     merge(summaryObj.toJson, jsonldContext)
   }
 

--- a/src/main/scala/org/phenoscape/owlery/Util.scala
+++ b/src/main/scala/org/phenoscape/owlery/Util.scala
@@ -1,0 +1,13 @@
+package org.phenoscape.owlery
+
+import com.google.common.base.Optional
+
+object Util {
+
+  implicit class OptionalOption[T](val self: Optional[T]) extends AnyVal {
+
+    def asScala: Option[T] = if (self.isPresent) Some(self.get) else None
+
+  }
+
+}


### PR DESCRIPTION
Sample output:

```json
{
    "label": "go",
    "logicalAxiomsCount": 346708,
    "@context": "https://owlery.phenoscape.org/json/context.jsonld",
    "isConsistent": true,
    "imports": [
        {
            "@id": "http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl"
        },
        {
            "@id": "http://purl.obolibrary.org/obo/go/extensions/go-plus.owl",
            "version": "http://purl.obolibrary.org/obo/go/releases/2019-07-01/extensions/go-plus.owl"
        },
        {
            "@id": "http://purl.obolibrary.org/obo/go/extensions/gorel.owl"
        },
        {
            "@id": "http://purl.obolibrary.org/obo/cl/cl-simple.owl",
            "version": "http://purl.obolibrary.org/obo/cl/2019-07-16/cl-simple.owl"
        },
        {
            "@id": "http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl"
        }
    ],
    "@id": "http://purl.obolibrary.org/obo/go/extensions/go-gaf.owl"
}
```