### PR TITLE
Add comments explaining configuration options.

### DIFF
--- a/src/main/resources/application.conf.example
+++ b/src/main/resources/application.conf.example
@@ -25,7 +25,12 @@ owlery {
 		{
 			name = tto
 			location = "/Users/jim/Desktop/owlery/tto"
+                        # location may be a local directory name or a URL.
 			reasoner = structural
+                        # reasoner should be "structural", "elk", "hermit", "jfact", or "whelk"
+                        # structural does no DL reasoning
+                        # elk and whelk are limited to the OWL EL profile
+                        # hermit and jfact are OWL DL reasoners.
 		}
 	]
 }


### PR DESCRIPTION
Explained possible values for location and reasoner kb options.

Note that I am not at all sure that I have covered all of the location options, since I don't know all the possibilities.  I *believe* that one can provide:
* A directory pathname and Owlery will load all files in that directory into the KB
* A URL and Owlery will load the ontology at the URL and its imports (?)

I don't know how the `kb` > `catalog` option is used, so I couldn't add a comment about that.