### PR TITLE
Add ontology location docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ owlery {
   host = localhost
   kbs = [
           {
-            name = uberon
+            name = myproject
             location = "http://example.org/my-importer-ont.owl"
             reasoner = hermit
             catalog = "/data/project/catalog.xml"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It also provides a web service front-end for [Owlet](https://github.com/phenosca
 
 ## Examples
 
- * [phenoscape owlery api](https://owlery.phenoscape.org/api/)
+ * [phenoscape owlery api](https://owlery.phenoscape.org/api/) _This link needs to be updated to reflect the current Owlery API location_
      * [swagger.json](https://owlery.phenoscape.org/json/swagger.json)
 
 ## Running Owlery
@@ -20,6 +20,39 @@ It also provides a web service front-end for [Owlet](https://github.com/phenosca
 
 * Configuration file template: https://github.com/phenoscape/owlery/blob/master/src/main/resources/application.conf.example
 * Your own configuration file can be specified with a JVM argument, e.g.: `-Dconfig.file=/etc/default/owlery.conf`
+
+#### Specifying ontology file(s) to load
+
+The `location` property for each knowledgebase specifies which ontologies to load into Owlery. This property can be a path or an IRI. If the path is a folder, all files in the folder will be imported into one ontology. If the path is a file, that file will be directly loaded as an ontology. If the value is an IRI, the ontology will be retrieved from that IRI.
+
+##### Locating ontologies via IRI
+
+By default, an ontology specified by IRI will be downloaded from the web using that IRI. This applies to a `location` configuration value as well as to any ontologies imported via `owl:imports` within any loaded ontology. You can use the `catalog` property for a kb to map ontology IRIs to other URLs or filesystem paths by providing a catalog XML file, as is done in Protégé. For example, `application.conf` could be:
+
+```
+owlery {
+  port = 8080
+  host = localhost
+  kbs = [
+          {
+            name = uberon
+            location = "http://example.org/my-importer-ont.owl"
+            reasoner = hermit
+            catalog = "/data/project/catalog.xml"
+          }
+        ]
+}
+```
+
+Say the ontology `http://example.org/my-importer-ont.owl` contains an `owl:imports` statement pointing to `http://example.org/my-terminology.owl`. `/data/project.catalog.xml` might look like this:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri name="http://example.org/my-importer-ont.owl" uri="/data/ontologies/my-importer-ont.owl"/>
+    <uri name="http://example.org/my-terminology.owl" uri="/data/ontologies/my-terminology.owl"/>
+</catalog>
+```
 
 ### Experimenting with the API
 


### PR DESCRIPTION
@rpgoldman I think you may find this helpful. Since your ontologies import each other, it will probably work best to put the ontology IRI of the root ontology in your `location` property. Then provide a `catalog` file that maps all ontology IRIs to filesystem locations on your machine.