### PR TITLE
Improve logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,15 +37,16 @@ libraryDependencies ++= {
     "com.typesafe.akka"      %% "akka-http-spray-json"   % "10.2.6",
     "ch.megard"              %% "akka-http-cors"         % "1.1.2",
     "io.spray"               %% "spray-json"             % "1.3.5",
-    "net.sourceforge.owlapi" %  "owlapi-distribution"    % "4.5.20",
-    "org.semanticweb.elk"    %  "elk-owlapi"             % "0.4.3",
+    "net.sourceforge.owlapi" %  "owlapi-distribution"    % "4.5.20" exclude("org.slf4j", "slf4j-log4j12"),
+    "org.semanticweb.elk"    %  "elk-owlapi"             % "0.4.3" exclude("log4j", "log4j"),
     "net.sourceforge.owlapi" %  "org.semanticweb.hermit" % "1.4.3.456",
     "net.sourceforge.owlapi" %  "jfact"                  % "4.0.4",
     "org.geneontology"       %% "whelk-owlapi"           % "1.1.1",
-    "org.phenoscape"         %% "owlet"                  % "1.9",
+    "org.phenoscape"         %% "owlet"                  % "1.9" exclude("org.slf4j", "slf4j-log4j12"),
     "commons-io"             %  "commons-io"             % "2.11.0",
-    "org.apache.jena"        %  "apache-jena-libs"       % "4.1.0",
+    "org.apache.jena"        %  "apache-jena-libs"       % "4.1.0" exclude("org.slf4j", "slf4j-log4j12"),
     "org.obolibrary.robot"   %  "robot-core"             % "1.4.3" exclude("org.slf4j", "slf4j-log4j12"),
+    "ch.qos.logback"         %  "logback-classic"        % "1.2.3",
     "com.lihaoyi"            %% "utest"                  % "0.7.10" % Test
   )
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="10 seconds">
+
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%highlight(%msg) %n</Pattern>
+        </encoder>
+    </appender>
+
+
+    <appender name="files" class="ch.qos.logback.core.FileAppender">
+        <file>${user.home}/.Protege/logs/protege.log</file>
+        <append>true</append>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{0}    %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+
+    <root level="DEBUG">
+        <appender-ref ref="stdout" />
+        <appender-ref ref="files"/>
+    </root>
+
+
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <Pattern>%highlight(%msg) %n</Pattern>
+            <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{0}    %msg%n</Pattern>
         </encoder>
     </appender>
 

--- a/src/main/scala/org/phenoscape/owlery/Main.scala
+++ b/src/main/scala/org/phenoscape/owlery/Main.scala
@@ -1,5 +1,6 @@
 package org.phenoscape.owlery
 
+import akka.event.Logging
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonMarshaller
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.{ExceptionHandler, HttpApp, Route, ValidationRejection}
@@ -87,124 +88,126 @@ object Main extends HttpApp with App {
 
   def routes: Route = Route.seal {
     cors() {
-      pathPrefix("docs") {
-        pathEnd {
-          redirect(Uri("docs/"), StatusCodes.MovedPermanently)
-        } ~
-          pathSingleSlash {
-            getFromResource("docs/index.html")
+      logRequestResult("", Logging.InfoLevel) {
+        pathPrefix("docs") {
+          pathEnd {
+            redirect(Uri("docs/"), StatusCodes.MovedPermanently)
           } ~
-          getFromResourceDirectory("docs")
-      } ~
-        pathPrefix("kbs") {
-          pathPrefix(Segment) { kbName =>
-            Owlery.kb(kbName) match {
-              case None     => reject
-              case Some(kb) =>
-                path("subclasses") {
-                  objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
-                    parameters("direct".?(false), "includeEquivalent".?(false), "includeNothing".?(false), "includeDeprecated".?(true)) { (direct, includeEquivalent, includeNothing, includeDeprecated) =>
-                      complete {
-                        kb.querySubClasses(expression, direct, includeEquivalent, includeNothing, includeDeprecated)
-                      }
-                    }
-                  }
-                } ~
-                  path("superclasses") {
+            pathSingleSlash {
+              getFromResource("docs/index.html")
+            } ~
+            getFromResourceDirectory("docs")
+        } ~
+          pathPrefix("kbs") {
+            pathPrefix(Segment) { kbName =>
+              Owlery.kb(kbName) match {
+                case None     => reject
+                case Some(kb) =>
+                  path("subclasses") {
                     objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
-                      parameters("direct".?(false), "includeEquivalent".?(false), "includeThing".?(false), "includeDeprecated".?(true)) { (direct, includeEquivalent, includeThing, includeDeprecated) =>
+                      parameters("direct".?(false), "includeEquivalent".?(false), "includeNothing".?(false), "includeDeprecated".?(true)) { (direct, includeEquivalent, includeNothing, includeDeprecated) =>
                         complete {
-                          kb.querySuperClasses(expression, direct, includeEquivalent, includeThing, includeDeprecated)
+                          kb.querySubClasses(expression, direct, includeEquivalent, includeNothing, includeDeprecated)
                         }
                       }
                     }
                   } ~
-                  path("instances") {
-                    objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
-                      parameters("direct".?(false), "includeDeprecated".?(true)) { (direct, includeDeprecated) =>
-                        complete {
-                          kb.queryInstances(expression, direct, includeDeprecated)
-                        }
-                      }
-                    }
-                  } ~
-                  path("equivalent") {
-                    objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
-                      parameters("includeDeprecated".?(true)) { includeDeprecated =>
-                        complete {
-                          kb.queryEquivalentClasses(expression, includeDeprecated)
-                        }
-                      }
-                    }
-                  } ~
-                  path("satisfiable") {
-                    objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
-                      complete {
-                        kb.isSatisfiable(expression)
-                      }
-                    }
-                  } ~
-                  path("types") {
-                    parameters("object", "prefixes".as[Map[String, String]].?(NoPrefixes)).as(PrefixedIndividualIRI) { preIRI =>
-                      parameters("direct".?(true), "includeThing".?(false), "includeDeprecated".?(true)) { (direct, includeThing, includeDeprecated) =>
-                        complete {
-                          kb.queryTypes(factory.getOWLNamedIndividual(preIRI.iri), direct, includeThing, includeDeprecated)
-                        }
-                      }
-                    }
-                  } ~
-                  path("extract") {
-                    post {
-                      parameters("type".as[ModuleType].?(ModuleType.STAR), "ontologies".as[Seq[IRI]].?(Seq.empty[IRI])) { (moduleType, fromIRIs) =>
-                        handleWith(kb.extractModuleForOntology(_, moduleType, fromIRIs.toSet))
-                      }
-                    }
-                  } ~
-                  path("sparql") {
-                    get {
-                      parameter("query".as[Query]) { query =>
-                        complete {
-                          kb.performSPARQLQuery(query)
-                        }
-                      }
-                    } ~
-                      post {
-                        parameter("query".as[Query].?(NullQuery)) {
-                          case NullQuery => handleWith(kb.performSPARQLQuery)
-                          case query     => complete {
-                            kb.performSPARQLQuery(query)
+                    path("superclasses") {
+                      objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
+                        parameters("direct".?(false), "includeEquivalent".?(false), "includeThing".?(false), "includeDeprecated".?(true)) { (direct, includeEquivalent, includeThing, includeDeprecated) =>
+                          complete {
+                            kb.querySuperClasses(expression, direct, includeEquivalent, includeThing, includeDeprecated)
                           }
                         }
                       }
-                  } ~
-                  path("expand") {
-                    get {
-                      parameter("query".as[Query]) { query =>
-                        complete {
-                          kb.expandSPARQLQuery(query)
+                    } ~
+                    path("instances") {
+                      objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
+                        parameters("direct".?(false), "includeDeprecated".?(true)) { (direct, includeDeprecated) =>
+                          complete {
+                            kb.queryInstances(expression, direct, includeDeprecated)
+                          }
                         }
                       }
                     } ~
-                      post {
-                        handleWith(kb.expandSPARQLQuery)
+                    path("equivalent") {
+                      objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
+                        parameters("includeDeprecated".?(true)) { includeDeprecated =>
+                          complete {
+                            kb.queryEquivalentClasses(expression, includeDeprecated)
+                          }
+                        }
                       }
-                  } ~
-                  pathEnd {
-                    complete {
-                      kb.summary
+                    } ~
+                    path("satisfiable") {
+                      objectAndPrefixParametersToClass(kb.knownEntities) { expression =>
+                        complete {
+                          kb.isSatisfiable(expression)
+                        }
+                      }
+                    } ~
+                    path("types") {
+                      parameters("object", "prefixes".as[Map[String, String]].?(NoPrefixes)).as(PrefixedIndividualIRI) { preIRI =>
+                        parameters("direct".?(true), "includeThing".?(false), "includeDeprecated".?(true)) { (direct, includeThing, includeDeprecated) =>
+                          complete {
+                            kb.queryTypes(factory.getOWLNamedIndividual(preIRI.iri), direct, includeThing, includeDeprecated)
+                          }
+                        }
+                      }
+                    } ~
+                    path("extract") {
+                      post {
+                        parameters("type".as[ModuleType].?(ModuleType.STAR), "ontologies".as[Seq[IRI]].?(Seq.empty[IRI])) { (moduleType, fromIRIs) =>
+                          handleWith(kb.extractModuleForOntology(_, moduleType, fromIRIs.toSet))
+                        }
+                      }
+                    } ~
+                    path("sparql") {
+                      get {
+                        parameter("query".as[Query]) { query =>
+                          complete {
+                            kb.performSPARQLQuery(query)
+                          }
+                        }
+                      } ~
+                        post {
+                          parameter("query".as[Query].?(NullQuery)) {
+                            case NullQuery => handleWith(kb.performSPARQLQuery)
+                            case query     => complete {
+                              kb.performSPARQLQuery(query)
+                            }
+                          }
+                        }
+                    } ~
+                    path("expand") {
+                      get {
+                        parameter("query".as[Query]) { query =>
+                          complete {
+                            kb.expandSPARQLQuery(query)
+                          }
+                        }
+                      } ~
+                        post {
+                          handleWith(kb.expandSPARQLQuery)
+                        }
+                    } ~
+                    pathEnd {
+                      complete {
+                        kb.summary
+                      }
                     }
-                  }
-            }
-          } ~
-            pathEnd {
-              complete {
-                Owlery
               }
-            }
-        } ~
-        pathSingleSlash {
-          redirect(Uri("../docs/"), StatusCodes.SeeOther)
-        }
+            } ~
+              pathEnd {
+                complete {
+                  Owlery
+                }
+              }
+          } ~
+          pathSingleSlash {
+            redirect(Uri("../docs/"), StatusCodes.SeeOther)
+          }
+      }
     }
   }
 


### PR DESCRIPTION
Addresses #131. I added logback and tried to clean up the logging packages pulled in via various dependencies. I also turned on request logging within akka-http.

@rpgoldman you should now be able to provide your own logback.xml via the command line. I included one in `src/main/resources/logback.xml` that prints at the DEBUG level. You should see a lot of OWL API output.